### PR TITLE
Bump minimal Rails version from 5.0 to 6.1

### DIFF
--- a/r18n-rails.gemspec
+++ b/r18n-rails.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'net-smtp', '~> 0.3.1'
 
   s.add_dependency 'r18n-rails-api', '~> 5.0'
-  s.add_dependency 'rails', '>= 5.0', '< 8'
+  s.add_dependency 'rails', '>= 6.1', '< 8'
 
   s.add_development_dependency 'pry-byebug', '~> 3.9'
 


### PR DESCRIPTION
`rspec-rails` has updated their dependencies.

Rails 6.0 is in security maintenance, will be end soon.